### PR TITLE
소송장 생성 기능 수정

### DIFF
--- a/src/main/java/com/lawProject/SSL/domain/langchain/api/OllamaApiController.java
+++ b/src/main/java/com/lawProject/SSL/domain/langchain/api/OllamaApiController.java
@@ -3,6 +3,7 @@ package com.lawProject.SSL.domain.langchain.api;
 import com.lawProject.SSL.domain.langchain.dto.MakeDocForm;
 import com.lawProject.SSL.domain.langchain.service.OllamaApiClient;
 import com.lawProject.SSL.domain.lawsuit.dto.FileStorageResult;
+import com.lawProject.SSL.domain.lawsuit.model.LawsuitType;
 import com.lawProject.SSL.global.common.code.ErrorCode;
 import com.lawProject.SSL.global.common.code.SuccessCode;
 import com.lawProject.SSL.global.common.response.ApiResponse;
@@ -73,6 +74,18 @@ public class OllamaApiController {
      */
     @PostMapping("/doc/make")
     public Mono<ResponseEntity<ApiResponse<FileStorageResult>>> makeDoc(@RequestBody MakeDocForm makeDocForm, HttpServletRequest request) {
+        // 소송 유형에 따라 입력값 검증
+        if (makeDocForm.getLawsuitType() == LawsuitType.CIVIL) {
+            if (makeDocForm.getClaimAmount() == null) {
+                return Mono.just(ApiResponse.onFailure(ErrorCode._INVALID_INPUT_VALUE));
+            }
+        } else if (makeDocForm.getLawsuitType() == LawsuitType.CRIMINAL) {
+            if (makeDocForm.getDamageScale() == null) {
+                return Mono.just(ApiResponse.onFailure(ErrorCode._INVALID_INPUT_VALUE));
+            }
+        } else {
+            return Mono.just(ApiResponse.onFailure(ErrorCode._INVALID_INPUT_VALUE));
+        }
 
         return ollamaApiClient.makeDoc(makeDocForm, request)
                 .map(fileStorageResult -> ApiResponse.onSuccess(SuccessCode._OK, fileStorageResult))

--- a/src/main/java/com/lawProject/SSL/domain/langchain/dto/MakeDocForm.java
+++ b/src/main/java/com/lawProject/SSL/domain/langchain/dto/MakeDocForm.java
@@ -1,19 +1,25 @@
 package com.lawProject.SSL.domain.langchain.dto;
 
-import jakarta.validation.constraints.NotNull;
+import com.lawProject.SSL.domain.lawsuit.model.LawsuitType;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
 
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 public class MakeDocForm {
-    @NotNull
-    private String fileName;
-    @NotNull
-    private String name;
-    @NotNull
-    private String content;
-    //TODO AI 파트와 상의 후 수정 필요
+    private LawsuitType lawsuitType; // '민사' 또는 '형사'
+    private int defendantCount; // 피고 숫자 또는 피고소인 숫자
+    private String caseDescription; // 사건에 대한 서술
+    private BigDecimal claimAmount; // 피해 금액 or 청구할 금액 (민사)
+    private BigDecimal damageScale; // 피해 규모 (형사)
+
+    /*
+    BigDecimal 타입 사용 이유
+    - float, double 타입은 부동소수점 연산을 사용하는데 정밀도가 떨어질 수 있다.
+    하지만 BigDecimal 타입은 소수점 이하 자릿수의 정확성을 유지하면서 연산을 할 수 있어 정밀한 결과를 보장한다.
+     */
 }

--- a/src/main/java/com/lawProject/SSL/domain/langchain/dto/MakeDocForm.java
+++ b/src/main/java/com/lawProject/SSL/domain/langchain/dto/MakeDocForm.java
@@ -15,7 +15,7 @@ public class MakeDocForm {
     private int defendantCount; // 피고 숫자 또는 피고소인 숫자
     private String caseDescription; // 사건에 대한 서술
     private BigDecimal claimAmount; // 피해 금액 or 청구할 금액 (민사)
-    private BigDecimal damageScale; // 피해 규모 (형사)
+    private String damageScale; // 피해 규모 (형사)
 
     /*
     BigDecimal 타입 사용 이유

--- a/src/main/java/com/lawProject/SSL/domain/langchain/service/OllamaApiClient.java
+++ b/src/main/java/com/lawProject/SSL/domain/langchain/service/OllamaApiClient.java
@@ -10,8 +10,8 @@ import com.lawProject.SSL.domain.lawsuit.model.LawSuit;
 import com.lawProject.SSL.domain.lawsuit.model.LawsuitType;
 import com.lawProject.SSL.domain.lawsuit.repository.LawSuitRepository;
 import com.lawProject.SSL.domain.lawsuit.service.FileService;
-import com.lawProject.SSL.domain.user.service.UserService;
 import com.lawProject.SSL.domain.user.model.User;
+import com.lawProject.SSL.domain.user.service.UserService;
 import com.lawProject.SSL.global.common.code.ErrorCode;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -22,8 +22,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
-
-import java.time.LocalDateTime;
 
 @Slf4j
 @Service
@@ -85,17 +83,30 @@ public class OllamaApiClient {
                 .bodyValue(makeDocForm)
                 .retrieve()
                 .bodyToMono(Resource.class)
-                .flatMap(resource -> savedFile(request, resource, lawsuitType));
+                .flatMap(resource -> savedFileWithType(request, resource, lawsuitType));
     }
 
     /* Using Method */
     // 파일 저장
-    private Mono<FileStorageResult> savedFile(HttpServletRequest request, Resource fixedDocResource, LawsuitType lawsuitType) {
+    private Mono<FileStorageResult> savedFileWithType(HttpServletRequest request, Resource fixedDocResource, LawsuitType lawsuitType) {
         return Mono.fromCallable(() -> {
             FileStorageResult fileStorageResult = fileService.saveFixedFile(fixedDocResource);
             User user = userService.getUserInfo(request);
 
-            LawSuit lawSuit = LawSuit.ofUser(user, fileStorageResult, lawsuitType);
+            LawSuit lawSuit = LawSuit.ofUserWithType(user, fileStorageResult, lawsuitType);
+            lawSuitRepository.save(lawSuit);
+            user.addLawsuit(lawSuit);
+
+            return fileStorageResult;
+        });
+    }
+
+    private Mono<FileStorageResult> savedFile(HttpServletRequest request, Resource fixedDocResource) {
+        return Mono.fromCallable(() -> {
+            FileStorageResult fileStorageResult = fileService.saveFixedFile(fixedDocResource);
+            User user = userService.getUserInfo(request);
+
+            LawSuit lawSuit = LawSuit.ofUser(user, fileStorageResult);
             lawSuitRepository.save(lawSuit);
             user.addLawsuit(lawSuit);
 

--- a/src/main/java/com/lawProject/SSL/domain/lawsuit/model/LawSuit.java
+++ b/src/main/java/com/lawProject/SSL/domain/lawsuit/model/LawSuit.java
@@ -28,7 +28,6 @@ public class LawSuit extends BaseEntity {
     private LocalDateTime expireTime;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
     private LawsuitType lawsuitType;
 
     @ManyToOne(fetch = LAZY)
@@ -36,16 +35,21 @@ public class LawSuit extends BaseEntity {
     private User user;
 
     /* Using Method */
-    public void setExpireTime(LocalDateTime expireTime) {
-        this.expireTime = expireTime;
-    }
-
     public void setOriginalFileName(String newOriginalFileName) {
         this.originalFileName = newOriginalFileName;
     }
 
     /* 연관관계 메서드 */
-    public static LawSuit ofUser(User user, FileStorageResult fileStorageResult, LawsuitType lawsuitType) {
+    public static LawSuit ofUser(User user, FileStorageResult fileStorageResult) {
+        return LawSuit.builder()
+                .user(user)
+                .storedFileName(fileStorageResult.getStoredFileName())
+                .originalFileName(fileStorageResult.getOriginalFileName())
+                .expireTime(LocalDateTime.now().plusDays(30)) // 기본 만료 시간 설정
+                .build();
+    }
+
+    public static LawSuit ofUserWithType(User user, FileStorageResult fileStorageResult, LawsuitType lawsuitType) {
         return LawSuit.builder()
                 .user(user)
                 .storedFileName(fileStorageResult.getStoredFileName())

--- a/src/main/java/com/lawProject/SSL/domain/lawsuit/model/LawSuit.java
+++ b/src/main/java/com/lawProject/SSL/domain/lawsuit/model/LawSuit.java
@@ -27,6 +27,10 @@ public class LawSuit extends BaseEntity {
 
     private LocalDateTime expireTime;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private LawsuitType lawsuitType;
+
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "user_id")
     private User user;
@@ -41,11 +45,13 @@ public class LawSuit extends BaseEntity {
     }
 
     /* 연관관계 메서드 */
-    public static LawSuit ofUser(User user, FileStorageResult fileStorageResult) {
+    public static LawSuit ofUser(User user, FileStorageResult fileStorageResult, LawsuitType lawsuitType) {
         return LawSuit.builder()
                 .user(user)
                 .storedFileName(fileStorageResult.getStoredFileName())
                 .originalFileName(fileStorageResult.getOriginalFileName())
+                .lawsuitType(lawsuitType)
+                .expireTime(LocalDateTime.now().plusDays(30)) // 기본 만료 시간 설정
                 .build();
     }
 }

--- a/src/main/java/com/lawProject/SSL/domain/lawsuit/model/LawsuitType.java
+++ b/src/main/java/com/lawProject/SSL/domain/lawsuit/model/LawsuitType.java
@@ -1,0 +1,21 @@
+package com.lawProject.SSL.domain.lawsuit.model;
+
+public enum LawsuitType {
+    CIVIL("민사"),
+    CRIMINAL("형사");
+
+    private final String type;
+
+    LawsuitType(String type) {
+        this.type = type;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    @Override
+    public String toString() {
+        return type;
+    }
+}

--- a/src/main/java/com/lawProject/SSL/domain/lawsuit/repository/LawSuitRepository.java
+++ b/src/main/java/com/lawProject/SSL/domain/lawsuit/repository/LawSuitRepository.java
@@ -4,6 +4,7 @@ import com.lawProject.SSL.domain.lawsuit.model.LawSuit;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -12,4 +13,7 @@ public interface LawSuitRepository extends JpaRepository<LawSuit, Long> {
     Optional<LawSuit> findByStoredFileName(String StoredFileName);
 
     List<LawSuit> findAllByUserIdOrderByIdDesc(Long userId);
+
+    // 만료 기한이 지난 LawSuit 찾기
+    List<LawSuit> findByExpireTimeBefore(LocalDateTime localDateTime);
 }


### PR DESCRIPTION
## PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [x] 기능 수정
- [x] 코드 리팩토링
- [ ] 버그 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더의 변경
- [x] 주석 혹은 문서 수정

### PR 요약
- AI 파트와의 회의를 통해 기존에 공란으로 두었던 '소송장 첨삭' API의 Request Dto 양식을 정리했습니다.
- 스케쥴러를 활용해 만료기한 30일이 지난 소송장 파일을 자동으로 삭제하도록 구현했습니다.
- 우선 소송장 생성시 소송장의 종류를 Enum 타입인 LawSuitType로 저장하도록 했습니다.

### 변경 사항
소송장 첨삭 API의 Request Dto 양식 정리
스케쥴러를 활용한 파일 자동 삭제 메서드 개발

### 추가로 알리고 싶은 내용
현재까지는 소송장 첨삭의 경우에는 LawSuitType를 저장하지 않는데 이는 추후 논의가 필요할 거 같습니다.

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 본인을 Assign해주시고, 본인을 제외한 백엔드 개발자를 Reviewer로 지정해주세요.
- [x] 라벨 체크해주세요.
